### PR TITLE
Feat/sarangbang list

### DIFF
--- a/app/dev/debug/output-metadata.json
+++ b/app/dev/debug/output-metadata.json
@@ -1,0 +1,21 @@
+{
+  "version": 3,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "com.lanpet.app.dev",
+  "variantName": "devDebug",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "attributes": [],
+      "versionCode": 1,
+      "versionName": "1.0.0",
+      "outputFile": "app-dev-debug.apk"
+    }
+  ],
+  "elementType": "File",
+  "minSdkVersionForDexing": 24
+}

--- a/core/common/src/main/java/com/lanpet/core/common/widget/FreeBoardListItem.kt
+++ b/core/common/src/main/java/com/lanpet/core/common/widget/FreeBoardListItem.kt
@@ -32,6 +32,7 @@ import com.lanpet.core.designsystem.theme.GrayColor
 import com.lanpet.core.designsystem.theme.LanPetAppTheme
 import com.lanpet.core.designsystem.theme.LanPetDimensions
 import com.lanpet.core.designsystem.theme.customTypography
+import com.lanpet.domain.model.FreeBoardCategoryType
 import com.lanpet.domain.model.FreeBoardPost
 import com.lanpet.domain.model.PetCategory
 
@@ -166,6 +167,7 @@ private fun FreeBoardListItemPreview() {
                         commentCount = 9,
                         petCategory = PetCategory.DOG,
                         images = listOf(),
+                        freeBoardCategoryType = FreeBoardCategoryType.ALL,
                     ),
             )
             Spacer(modifier = Modifier.padding(LanPetDimensions.Spacing.small))
@@ -181,6 +183,7 @@ private fun FreeBoardListItemPreview() {
                         likeCount = 999,
                         commentCount = 9,
                         petCategory = PetCategory.DOG,
+                        freeBoardCategoryType = FreeBoardCategoryType.ALL,
                         images =
                             listOf(
                                 "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="next_button_string">다음</string>
     <string name="prev_button_string">뒤로</string>
     <string name="start_button_string">시작하기</string>
+    <string name="title_appbar_freeboard">사랑방</string>
 </resources>

--- a/core/di/src/dev/kotlin/com/lanpet/core/di/ApiModuleDev.kt
+++ b/core/di/src/dev/kotlin/com/lanpet/core/di/ApiModuleDev.kt
@@ -14,4 +14,11 @@ object ApiModuleDev {
     @Provides
     @Named("BaseApiUrl")
     fun provideBaseApiUrl(): String = "https://test.api.lanpet.co.kr/"
+
+    @Singleton
+    @Provides
+    @Named("FreeBoardApiUrl")
+    fun provideFreeBoardApiUrl(
+        @Named("BaseApiUrl") baseUrl: String,
+    ): String = baseUrl + "sarangbangs/"
 }

--- a/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
+++ b/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
@@ -42,7 +42,7 @@ object ApiModule {
     @Singleton
     @Provides
     fun provideFreeBoardApiClient(
-        @Named("BaseApiUrl") baseApiUrl: String,
+        @Named("FreeBoardBaseApiUrl") baseApiUrl: String,
         authStateHolder: AuthStateHolder,
     ): FreeBoardApiClient = FreeBoardApiClient(baseApiUrl, authStateHolder)
 

--- a/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
+++ b/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
@@ -49,4 +49,11 @@ object ApiModule {
     @Singleton
     @Provides
     fun provideFreeBoardApiService(freeBoardApiClient: FreeBoardApiClient): FreeBoardApiService = freeBoardApiClient.getService()
+
+    @Singleton
+    @Provides
+    @Named("FreeBoardApiUrl")
+    fun provideFreeBoardApiUrl(
+        @Named("BaseApiUrl") baseUrl: String,
+    ): String = baseUrl + "sarangbangs/"
 }

--- a/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
+++ b/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
@@ -52,7 +52,7 @@ object ApiModule {
 
     @Singleton
     @Provides
-    @Named("FreeBoardApiUrl")
+    @Named("FreeBoardBaseApiUrl")
     fun provideFreeBoardApiUrl(
         @Named("BaseApiUrl") baseUrl: String,
     ): String = baseUrl + "sarangbangs/"

--- a/core/di/src/prod/kotlin/com/lanpet/core/di/ApiModuleProd.kt
+++ b/core/di/src/prod/kotlin/com/lanpet/core/di/ApiModuleProd.kt
@@ -15,4 +15,11 @@ object ApiModuleProd {
     @Provides
     @Named("BaseApiUrl")
     fun provideBaseApiUrl(): String = "https://test.api.lanpet.co.kr/"
+
+    @Singleton
+    @Provides
+    @Named("FreeBoardApiUrl")
+    fun provideFreeBoardApiUrl(
+        @Named("BaseApiUrl") baseUrl: String,
+    ): String = baseUrl + "sarangbangs/"
 }

--- a/core/di/src/prod/kotlin/com/lanpet/core/di/ApiModuleProd.kt
+++ b/core/di/src/prod/kotlin/com/lanpet/core/di/ApiModuleProd.kt
@@ -7,10 +7,10 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import javax.inject.Singleton
 
+// TODO("Satoshi"): replace with production endpoint
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModuleProd {
-    // TODO("Satoshi"): replace with production endpoint
     @Singleton
     @Provides
     @Named("BaseApiUrl")

--- a/data/dto/src/main/java/com/lanpet/data/dto/freeboard/FreeBoardListResponse.kt
+++ b/data/dto/src/main/java/com/lanpet/data/dto/freeboard/FreeBoardListResponse.kt
@@ -1,0 +1,39 @@
+package com.lanpet.data.dto.freeboard
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FreeBoardListResponse(
+    val items: List<FreeBoardItem>?,
+    val totalCount: Int?,
+    val nextCursor: String?,
+)
+
+@Serializable
+data class FreeBoardItem(
+    val id: String,
+    val category: String,
+    val petType: String,
+    val text: FreeBoardText,
+    val stat: FreeBoardStat?,
+    val resources: List<FreeBoardResource>?,
+    val created: String,
+)
+
+@Serializable
+data class FreeBoardText(
+    val title: String,
+    val content: String,
+)
+
+@Serializable
+data class FreeBoardStat(
+    val likeCount: Int?,
+    val commentCount: Int?,
+)
+
+@Serializable
+data class FreeBoardResource(
+    val id: String,
+    val url: String,
+)

--- a/data/dto/src/main/java/com/lanpet/data/dto/typeadapter/FreeBoardCategoryTypeTypeAdapter.kt
+++ b/data/dto/src/main/java/com/lanpet/data/dto/typeadapter/FreeBoardCategoryTypeTypeAdapter.kt
@@ -1,0 +1,21 @@
+package com.lanpet.data.dto.typeadapter
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.lanpet.domain.model.FreeBoardCategoryType
+
+class FreeBoardCategoryTypeTypeAdapter : TypeAdapter<FreeBoardCategoryType>() {
+    override fun write(
+        out: JsonWriter?,
+        value: FreeBoardCategoryType?,
+    ) {
+        out?.let {
+            value?.let {
+                out.value(value.value)
+            }
+        }
+    }
+
+    override fun read(`in`: JsonReader?): FreeBoardCategoryType? = FreeBoardCategoryType.fromValue(`in`?.nextString())
+}

--- a/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiClient.kt
+++ b/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiClient.kt
@@ -3,8 +3,10 @@ package com.lanpet.data.service
 import com.google.gson.GsonBuilder
 import com.lanpet.core.manager.AuthStateHolder
 import com.lanpet.data.dto.typeadapter.AuthorityTypeTypeAdapter
+import com.lanpet.data.dto.typeadapter.FreeBoardCategoryTypeTypeAdapter
 import com.lanpet.domain.model.AuthState
 import com.lanpet.domain.model.AuthorityType
+import com.lanpet.domain.model.FreeBoardCategoryType
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -43,7 +45,10 @@ class FreeBoardApiClient
                 .registerTypeAdapter(
                     AuthorityType::class.java,
                     AuthorityTypeTypeAdapter(),
-                ).create()
+                ).registerTypeAdapter(
+                    FreeBoardCategoryType::class.java,
+                    FreeBoardCategoryTypeTypeAdapter(),
+               ).create()
 
         private val okHttpClient = OkHttpClient.Builder().addInterceptor(headerInterceptor).build()
 

--- a/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
+++ b/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
@@ -4,13 +4,16 @@ import com.lanpet.domain.model.FreeBoardComment
 import com.lanpet.domain.model.FreeBoardPost
 import com.lanpet.domain.model.FreeBoardPostDetail
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface FreeBoardApiService {
     @GET
     suspend fun getFreeBoardPostList(): List<FreeBoardPost>
 
     @GET
-    suspend fun getFreeBoardPostDetail(id: String): FreeBoardPostDetail
+    suspend fun getFreeBoardPostDetail(
+        @Path("id") id: String,
+    ): FreeBoardPostDetail
 
     @GET
     suspend fun getFreeBoardPostCommentList(id: String): List<FreeBoardComment>

--- a/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
+++ b/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
@@ -16,7 +16,7 @@ interface FreeBoardApiService {
     @GET
     suspend fun getFreeBoardPostList(): List<FreeBoardPost>
 
-    @GET("/{id}")
+    @GET("{id}")
     suspend fun getFreeBoardPostDetail(
         @Path("id") id: String,
     ): FreeBoardPostDetail
@@ -24,13 +24,13 @@ interface FreeBoardApiService {
     @GET
     suspend fun getFreeBoardPostCommentList(id: String): List<FreeBoardComment>
 
-    @POST("/sarangbangs")
+    @POST
     suspend fun createFreeBoardPost(
         @Body
         createFreeBoardPostRequest: CreateFreeBoardPostRequest,
     ): CreateFreeBoardPostResponse
 
-    @POST("/sarangbangs/{sarangbangId}/resources")
+    @POST("{sarangbangId}/resources")
     suspend fun getResourceUploadUrl(
         @Path("sarangbangId")
         sarangbangId: String,

--- a/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardCategoryType.kt
+++ b/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardCategoryType.kt
@@ -8,4 +8,9 @@ enum class FreeBoardCategoryType(
     COMMUNICATE(title = "소통해요", value = "COMMUNICATION"),
     RECOMMEND(title = "추천해요", value = "RECOMMENDATION"),
     QUESTION(title = "궁금해요", value = "CURIOUS"),
+    ;
+
+    companion object {
+        fun fromValue(value: String?): FreeBoardCategoryType? = FreeBoardCategoryType.entries.find { it.value == value }
+    }
 }

--- a/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardCategoryType.kt
+++ b/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardCategoryType.kt
@@ -1,10 +1,11 @@
 package com.lanpet.domain.model
 
 enum class FreeBoardCategoryType(
-    val value: String,
+    val value: String?,
+    val title: String,
 ) {
-    ALL("전체"),
-    COMMUNICATE("소통해요"),
-    RECOMMEND("추천해요"),
-    QUESTION("궁금해요"),
+    ALL(title = "전체", value = null),
+    COMMUNICATE(title = "소통해요", value = "COMMUNICATION"),
+    RECOMMEND(title = "추천해요", value = "RECOMMENDATION"),
+    QUESTION(title = "궁금해요", value = "CURIOUS"),
 }

--- a/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardPost.kt
+++ b/domain/model/src/main/java/com/lanpet/domain/model/FreeBoardPost.kt
@@ -7,6 +7,7 @@ import java.util.TimeZone
 data class FreeBoardPost(
     val id: Int,
     val petCategory: PetCategory,
+    val freeBoardCategoryType: FreeBoardCategoryType,
     val title: String,
     val tags: List<String>,
     val content: String,
@@ -16,6 +17,8 @@ data class FreeBoardPost(
     val likeCount: Int,
     val commentCount: Int,
 ) {
+
+    @Deprecated("Core:common:extension 에 정의되어있는 함수를 사용하세요")
     // UTC 문자열을 파싱하여 한국 시간으로 변환
     val createdAtKorString: String
         get() {

--- a/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardScreen.kt
+++ b/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardScreen.kt
@@ -1,8 +1,17 @@
 package com.lanpet.free.screen
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -12,19 +21,28 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.lanpet.core.common.widget.LanPetTopAppBar
+import com.lanpet.core.common.widget.SelectableChip
 import com.lanpet.core.designsystem.R
 import com.lanpet.core.designsystem.theme.LanPetAppTheme
+import com.lanpet.core.designsystem.theme.LanPetDimensions
 import com.lanpet.core.designsystem.theme.PrimaryColor
 import com.lanpet.core.designsystem.theme.WhiteColor
+import com.lanpet.domain.model.FreeBoardCategoryType
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FreeBoardScreen(
     modifier: Modifier = Modifier,
     onNavigateUp: (() -> Unit)? = null,
     onNavigateToFreeBoardWrite: () -> Unit = {},
+    // TODO: 게시글 디테일 페이지로 이동. 게시글 디테일 id 필요할듯.
 ) {
+    val scrollState = rememberScrollState()
+
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(
@@ -42,6 +60,11 @@ fun FreeBoardScreen(
                 )
             }
         },
+        topBar = {
+            LanPetTopAppBar(
+                title = { Text(stringResource(R.string.title_appbar_freeboard)) },
+            )
+        },
         floatingActionButtonPosition = FabPosition.End,
     ) {
         Surface(
@@ -50,8 +73,53 @@ fun FreeBoardScreen(
                     .fillMaxSize()
                     .padding(it),
         ) {
-            Text("FreeBoardScreen")
+            Column(
+                modifier =
+                    Modifier.verticalScroll(
+                        state = scrollState,
+                    ),
+            ) {
+                FreeBoardCategorySection(
+                    modifier = Modifier.fillMaxSize(),
+                    selectedCategory = FreeBoardCategoryType.ALL,
+                    onCategoryClick = {},
+                )
+                FreeBoardPostList()
+            }
         }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun FreeBoardCategorySection(
+    selectedCategory: FreeBoardCategoryType,
+    modifier: Modifier = Modifier,
+    onCategoryClick: (String) -> Unit = {},
+) {
+    FlowRow(
+        modifier =
+            modifier.fillMaxWidth().padding(
+                horizontal = LanPetDimensions.Margin.Layout.horizontal,
+            ),
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        FreeBoardCategoryType.entries.forEach {
+            SelectableChip.Rounded(
+                isSelected = selectedCategory == it,
+                title = it.title,
+                onSelectedValueChange = {
+                    // TODO
+                    true
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun FreeBoardPostList(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxSize()) {
     }
 }
 

--- a/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardWriteScreen.kt
+++ b/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardWriteScreen.kt
@@ -259,7 +259,7 @@ private fun SelectBoardSection(
         ) {
             categories.forEach { category ->
                 SelectableChip.Rounded(
-                    title = category.value,
+                    title = category.title,
                     isSelected = selectedCategory == category,
                 ) { onCategorySelect(category) }
             }

--- a/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardWriteScreen.kt
+++ b/feature/free/src/main/java/com/lanpet/free/screen/FreeBoardWriteScreen.kt
@@ -257,7 +257,7 @@ private fun SelectBoardSection(
         ) {
             categories.forEach { category ->
                 SelectableChip.Rounded(
-                    title = category.value,
+                    title = category.title,
                     isSelected = selectedCategory == category.name,
                 ) { onCategorySelect(category.name) }
             }

--- a/feature/free/src/main/java/com/lanpet/free/viewmodel/FreeBoarListViewModel.kt
+++ b/feature/free/src/main/java/com/lanpet/free/viewmodel/FreeBoarListViewModel.kt
@@ -1,0 +1,68 @@
+package com.lanpet.free.viewmodel
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lanpet.domain.model.FreeBoardPost
+import com.lanpet.domain.usecase.freeboard.GetFreeBoardPostListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FreeBoarListViewModel
+    @Inject
+    constructor(
+        private val getFreeBoardPostListUseCase: GetFreeBoardPostListUseCase,
+    ) : ViewModel() {
+        private val _uiState: MutableStateFlow<FreeBoardListState> =
+            MutableStateFlow(FreeBoardListState.Loading)
+        val uiState = _uiState.asStateFlow()
+
+        // TODO("Satoshi"): Set UiEvent
+
+        fun getFreeBoardPostList() {
+            viewModelScope.launch {
+                runCatching {
+                    getFreeBoardPostListUseCase().collect {
+                        _uiState.value =
+                            if (it.isEmpty()) {
+                                FreeBoardListState.Empty
+                            } else {
+                                if(_uiState.value is FreeBoardListState.Success) {
+                                    FreeBoardListState.Success(
+                                        (uiState.value as FreeBoardListState.Success).data + it
+                                    )
+                                } else {
+                                FreeBoardListState.Success(
+
+                                )
+                            }
+                    }
+                }.onFailure {
+                    _uiState.value = FreeBoardListState.Error(it.message)
+                }
+            }
+        }
+    }
+
+@Stable
+sealed class FreeBoardListState {
+    @Stable
+    data object Loading : FreeBoardListState()
+
+    @Stable
+    data object Empty : FreeBoardListState()
+
+    @Stable
+    data class Success(
+        val data: List<FreeBoardPost>,
+    ) : FreeBoardListState()
+
+    @Stable
+    data class Error(
+        val message: String?,
+    ) : FreeBoardListState()
+}

--- a/feature/free/src/main/java/com/lanpet/free/viewmodel/FreeBoarListViewModel.kt
+++ b/feature/free/src/main/java/com/lanpet/free/viewmodel/FreeBoarListViewModel.kt
@@ -31,13 +31,8 @@ class FreeBoarListViewModel
                             if (it.isEmpty()) {
                                 FreeBoardListState.Empty
                             } else {
-                                if(_uiState.value is FreeBoardListState.Success) {
-                                    FreeBoardListState.Success(
-                                        (uiState.value as FreeBoardListState.Success).data + it
-                                    )
-                                } else {
                                 FreeBoardListState.Success(
-
+                                    (uiState.value as FreeBoardListState.Success).data + it,
                                 )
                             }
                     }

--- a/feature/myposts/src/main/java/com/lanpet/feature/myposts/MyPostsScreen.kt
+++ b/feature/myposts/src/main/java/com/lanpet/feature/myposts/MyPostsScreen.kt
@@ -39,6 +39,7 @@ import com.lanpet.core.designsystem.theme.LanPetAppTheme
 import com.lanpet.core.designsystem.theme.LanPetDimensions
 import com.lanpet.core.designsystem.theme.PrimaryColor
 import com.lanpet.core.designsystem.theme.customTypography
+import com.lanpet.domain.model.FreeBoardCategoryType
 import com.lanpet.domain.model.FreeBoardPost
 import com.lanpet.domain.model.PetCategory
 
@@ -112,6 +113,7 @@ fun MyPostsScreen(
                                         updatedAt = "",
                                         likeCount = 10,
                                         commentCount = 111,
+                                        freeBoardCategoryType = FreeBoardCategoryType.ALL,
                                     )
                                 },
                             onNavigateToFreeBoardDetail = onNavigateToFreeBoardDetail,


### PR DESCRIPTION
1. FreeBoardCategoryType 에서 title property 가 추가되었습니다.
네이밍 변경시 타입명 자체를 변경하는것보다 내부 프로퍼티를 변경하는것이 타입에 더 안정적인것 같습니다.
2. FreeBoaardApiService 에 baseUrl 이 아닌 FreeBoardBaseUrl 을 넘겨주게 됩니다.
기존 BaseUrl 에 Freeboard path 를 추가하여 BaseUrl 으로 설정하여 Service 쪽에서는 별도의 "/sarangbangs" path 값을 넘겨주지 않아도 됩니다.
(2번 같은 경우는 기존의 작업된 내용을 보니 BaseUrl 에서 path 를 service에 직접 선언하여 사용하고 있어 추후 해당부분을 리팩토링 하거나 기존의 방식을 계속 따르는것이 좋아보입니다. 둘다 사용해도 괜찮은 방법이지만 BaseUrl 자체가 캡슐화되어 추후 변경사항에 대해 조금 더 유연하게 대처가 가능하다는 장점이 있습니다.) 

확인 부탁드리고 "stash" 변경사항의 경우 제가 기존에 작업중이던 영역이므로 넘어가셔도 좋습니다. 감사합니다!