### PR TITLE
Fix/apiclient

### DIFF
--- a/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
+++ b/core/di/src/main/java/com/lanpet/core/di/ApiModule.kt
@@ -42,7 +42,7 @@ object ApiModule {
     @Singleton
     @Provides
     fun provideFreeBoardApiClient(
-        @Named("FreeBoardBaseApiUrl") baseApiUrl: String,
+        @Named("BaseApiUrl") baseApiUrl: String,
         authStateHolder: AuthStateHolder,
     ): FreeBoardApiClient = FreeBoardApiClient(baseApiUrl, authStateHolder)
 

--- a/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
+++ b/data/service/src/main/java/com/lanpet/data/service/FreeBoardApiService.kt
@@ -8,33 +8,37 @@ import com.lanpet.domain.model.FreeBoardPost
 import com.lanpet.domain.model.FreeBoardPostDetail
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Path
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface FreeBoardApiService {
-    @GET
+    @GET(PATH)
     suspend fun getFreeBoardPostList(): List<FreeBoardPost>
 
-    @GET("{id}")
+    @GET("$PATH/{id}")
     suspend fun getFreeBoardPostDetail(
         @Path("id") id: String,
     ): FreeBoardPostDetail
 
-    @GET
+    @GET(PATH)
     suspend fun getFreeBoardPostCommentList(id: String): List<FreeBoardComment>
 
-    @POST
+    @POST(PATH)
     suspend fun createFreeBoardPost(
         @Body
         createFreeBoardPostRequest: CreateFreeBoardPostRequest,
     ): CreateFreeBoardPostResponse
 
-    @POST("{sarangbangId}/resources")
+    @POST("$PATH/{sarangbangId}/resources")
     suspend fun getResourceUploadUrl(
         @Path("sarangbangId")
         sarangbangId: String,
         @Query("size")
         size: Int,
     ): ResourceUploadUrlResponse
+
+    companion object {
+        const val PATH = "/sarangbangs"
+    }
 }

--- a/feature/free/src/main/java/com/lanpet/free/navigation/FreeNavGraph.kt
+++ b/feature/free/src/main/java/com/lanpet/free/navigation/FreeNavGraph.kt
@@ -36,12 +36,8 @@ fun NavGraphBuilder.freeNavGraph(
             }
         }
         composable<FreeBoardWrite> {
-            val parentEntry = remember { navController.getBackStackEntry(FreeBoardBaseRoute) }
-            val viewModel = hiltViewModel<FreeBoardWriteViewModel>(parentEntry)
-
             FreeBoardWriteScreen(
                 onNavigateUp = onNavigateUp,
-                freeBoardWriteViewModel = viewModel,
             )
         }
     }


### PR DESCRIPTION
1. api 요청 실패하는 원인이 확인 되었습니다.
이전에 각 ApiService 별로 별도의 baseUrl 을 할당하고자 했었는데요 (ex. https://test.api.com/sarangbangs) retrofit service 가 생성될때 제가 의도한것과는 달리 sarangbangs 는 path로 인식하여 baseurl 은 여전히 test.api.com 으로 들어가고 있었습니다. 그로 인해서 path 를 설정하지않아 에러가 발생하고 있었습니다.
따라서, BaseUrl 은 공통으로 사용하고 service 내부에 PATH 값을 따로 두는것으로 변경하였습니다. (기존에 다른 apiService 들의 구현 방식과 동일합니다.)
2. FreeBoardWriteViewModel 의 경우 글쓰기 화면에서 벗어나면 사라져야하는데 navBackstack 에서 주입하고 있다보니 화면을 벗어나더라도 해당 navGraph 안에 있다면 계속해서 살아있던 문제가 있었습니다. 따라서 navGraph 내부에서가 아닌 Screen 내부에서 hiltViewModel() 을 호출하여 주입받는 방식으로 변경하였습니다.

확인 부탁드립니다 감사합니다!!